### PR TITLE
docs: add missing dependency for ROS2-Gazebo control

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,8 +31,10 @@ To use this package, you'll need the following:
 **Make sure to install the following ROS 2 Jazzy Jalisco packages:**
 
 ```bash
+sudo apt update
 sudo apt install -y \
      ros-jazzy-ros2-controllers \
+     ros-jazzy-ros2-control \
      ros-jazzy-gz-ros2-control \
      ros-jazzy-ros-gz \
      ros-jazzy-ros-gz-bridge \


### PR DESCRIPTION
Publishing to `/velocity` topic does not move the ackermann model unless the missing `ros-jazzy-ros2-control` dependency is added. 

The `ros-jazzy-ros2-control` is fixes the launch error:
```
ros2: error: argument Call 'ros2 <command> -h' for more detailed usage.: invalid choice: 'control'
```

Instructions to add this dependent package was added to the `README` file.