### PR TITLE
Add odometry & imu sensors & ROS 2 topics

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,6 +143,12 @@ The vehicle can be controlled by publishing the steering angle in radians and ve
 /velocity
 ```
 
+The following topics can be subscribed to access the vehicle's odometry & imu sensor data and retrieve its information:
+```bash
+/odom
+/imu
+```
+
 The following topics can be subscribed to access the camera image and retrieve its information:
 
 ```bash

--- a/config/ros_gz_bridge.yaml
+++ b/config/ros_gz_bridge.yaml
@@ -27,3 +27,9 @@
   ros_type_name: "tf2_msgs/msg/TFMessage"
   gz_type_name: "gz.msgs.Pose_V"
   direction: "GZ_TO_ROS"
+
+- ros_topic_name: "/odom"
+  gz_topic_name: "/odom"
+  ros_type_name: "nav_msgs/msg/Odometry"
+  gz_type_name: "gz.msgs.Odometry"
+  direction: GZ_TO_ROS

--- a/config/ros_gz_bridge.yaml
+++ b/config/ros_gz_bridge.yaml
@@ -33,3 +33,9 @@
   ros_type_name: "nav_msgs/msg/Odometry"
   gz_type_name: "gz.msgs.Odometry"
   direction: GZ_TO_ROS
+
+- ros_topic_name: "/imu"
+  gz_topic_name: "/imu"
+  ros_type_name: "sensor_msgs/msg/Imu"
+  gz_type_name: "gz.msgs.IMU"
+  direction: GZ_TO_ROS

--- a/model/vehicle.xacro
+++ b/model/vehicle.xacro
@@ -459,6 +459,13 @@
     <plugin filename="gz-sim-sensors-system" name="gz::sim::systems::Sensors">
       <render_engine>ogre2</render_engine>
     </plugin>
+
+    <plugin filename="gz-sim-odometry-publisher-system" name="gz::sim::systems::OdometryPublisher">
+      <odom_frame>odom</odom_frame>
+      <robot_base_frame>body_link</robot_base_frame> <odom_topic>odom</odom_topic>
+      <tf_topic>tf</tf_topic>
+      <dimensions>3</dimensions>
+    </plugin>
   </gazebo>
 
   <!-- Camera -->

--- a/model/vehicle.xacro
+++ b/model/vehicle.xacro
@@ -460,6 +460,9 @@
       <render_engine>ogre2</render_engine>
     </plugin>
 
+    <plugin filename="gz-sim-imu-system" name="gz::sim::systems::Imu">
+    </plugin>
+
     <plugin filename="gz-sim-odometry-publisher-system" name="gz::sim::systems::OdometryPublisher">
       <odom_frame>odom</odom_frame>
       <robot_base_frame>body_link</robot_base_frame> <odom_topic>odom</odom_topic>
@@ -504,6 +507,58 @@
         <distortionT1>0.0</distortionT1>
         <distortionT2>0.0</distortionT2>
       </plugin>
+    </sensor>
+  </gazebo>
+
+  <!-- IMU sensor -->
+  <gazebo reference="body_link">
+    <sensor name="imu_sensor" type="imu">
+      <always_on>1</always_on>
+      <update_rate>50</update_rate>
+      <visualize>true</visualize>
+      <topic>imu</topic>
+      <imu>
+        <angular_velocity>
+          <x>
+            <noise type="gaussian">
+              <mean>0.0</mean>
+              <stddev>2e-4</stddev>
+            </noise>
+          </x>
+          <y>
+            <noise type="gaussian">
+              <mean>0.0</mean>
+              <stddev>2e-4</stddev>
+            </noise>
+          </y>
+          <z>
+            <noise type="gaussian">
+              <mean>0.0</mean>
+              <stddev>2e-4</stddev>
+            </noise>
+          </z>
+        </angular_velocity>
+        <linear_acceleration>
+          <x>
+            <noise type="gaussian">
+              <mean>0.0</mean>
+              <stddev>1.7e-2</stddev>
+            </noise>
+          </x>
+          <y>
+            <noise type="gaussian">
+              <mean>0.0</mean>
+              <stddev>1.7e-2</stddev>
+            </noise>
+          </y>
+          <z>
+            <noise type="gaussian">
+              <mean>0.0</mean>
+              <stddev>1.7e-2</stddev>
+            </noise>
+          </z>
+        </linear_acceleration>
+      </imu>
     </sensor>
   </gazebo>
 


### PR DESCRIPTION
To allow feedback of the current model's position, orientation, linear velocity, angular velocity, and linear acceleration for future projects, without feedback only open-loop control is possible. 

Two new ROS2 topics `/odom` & `/imu` were created to be used by other ROS2 nodes as sensor readings. 